### PR TITLE
some changes on how to show the cts/vts version for EAP builds

### DIFF
--- a/lcr/utils.py
+++ b/lcr/utils.py
@@ -55,3 +55,15 @@ def download_urllib(url, path):
     if not check_dict['file_not_exist']:
         logger.info("File is saved to %s" % path)
     return check_dict['file_not_exist']
+
+
+def download_url_content(request_url):
+    content = ""
+    r = requests.get(request_url)
+    if not r.ok and r.status_code == 404:
+        logger.info("failed to get content because the url %s is not found" % request_url)
+    elif not r.ok or r.status_code != 200:
+        logger.info("Failed %s %s %s" % (r.url, r.reason, r.status_code))
+    else:
+        content = r.text
+    return content

--- a/lkft/views.py
+++ b/lkft/views.py
@@ -1590,7 +1590,7 @@ def list_all_jobs(request):
                 )
 
 
-def get_cts_vss_version_from(cts_vts_url):
+def get_cts_vts_version_from(cts_vts_url):
     if cts_vts_url is None or len(cts_vts_url) ==0:
         return cts_vts_url
 
@@ -1617,9 +1617,9 @@ def get_build_metadata(build_metadata_url=None, project_name=None):
     build_metadata['toolchain'] = build_metadata_raw.get('toolchain')
 
     build_metadata['vts_url'] = build_metadata_raw.get('vts-url')
-    build_metadata['vts_version'] = get_cts_vss_version_from(build_metadata_raw.get('vts-url'))
+    build_metadata['vts_version'] = get_cts_vts_version_from(build_metadata_raw.get('vts-url'))
     build_metadata['cts_url'] = build_metadata_raw.get('cts-url')
-    build_metadata['cts_version'] = get_cts_vss_version_from(build_metadata_raw.get('cts-url'))
+    build_metadata['cts_version'] = get_cts_vts_version_from(build_metadata_raw.get('cts-url'))
 
     return build_metadata
 


### PR DESCRIPTION
This is temporary solution, will change to use the value from build metadata which is generated by the ci build scripts