### PR TITLE
kernelreport.py: move the check of build version earlier

### DIFF
--- a/lkft/management/commands/kernelreport.py
+++ b/lkft/management/commands/kernelreport.py
@@ -659,9 +659,26 @@ def find_best_two_runs(builds, project_name, project, exact):
         baseExactVersionDict = versiontoMME(exact) 
 
     for build in builds:
-        logger.info("Checking %s, %s", project_name, build.get('version'))
         if bailaftertwo == 2:
             break
+        elif bailaftertwo == 0 :
+            baseVersionDict = versiontoMME(build['version'])
+            if baseExactVersionDict is not None:
+                if baseVersionDict['Extra'] != baseExactVersionDict['Extra']:
+                    logger.info('Skip the check as it not the specified version for %s %s', project_name, build['version'])
+                    continue
+            # print "baseset"
+        elif bailaftertwo == 1 :
+            nextVersionDict = versiontoMME(build['version'])
+            if nextVersionDict['Extra'] == baseVersionDict['Extra']:
+                nextRc = nextVersionDict.get('rc')
+                baseRc = baseVersionDict.get('rc')
+                if (nextRc is None and baseRc is None) \
+                        or (nextRc is not None and baseRc is not None and nextRc == baseRc):
+                    logger.info('Skip the check as it has the same version for %s %s', project_name, build['version'])
+                    continue
+
+        logger.info("Checking for %s, %s", project_name, build.get('version'))
         build_number_passed = 0
         build_number_failed = 0
         build_number_total = 0
@@ -760,20 +777,6 @@ def find_best_two_runs(builds, project_name, project, exact):
         if jobTransactionStatus['vts'] == 'true' and jobTransactionStatus['cts'] == 'true':
             # and jobTransactionStatus['boot'] == 'true' :
             #pdb.set_trace()
-            if bailaftertwo == 0 :
-                baseVersionDict = versiontoMME(build['version'])
-                if baseExactVersionDict is not None:
-                    if baseVersionDict['Extra'] != baseExactVersionDict['Extra']:
-                        continue
-                # print "baseset"
-            elif bailaftertwo == 1 :
-                nextVersionDict = versiontoMME(build['version'])
-                if nextVersionDict['Extra'] == baseVersionDict['Extra']:
-                    nextRc = nextVersionDict.get('rc')
-                    baseRc = baseVersionDict.get('rc')
-                    if (nextRc is None and baseRc is None) \
-                        or (nextRc is not None and baseRc is not None and nextRc == baseRc):
-                        continue
 
             tallyNumbers(build, jobTransactionStatus)
 

--- a/lkft/views.py
+++ b/lkft/views.py
@@ -1596,14 +1596,15 @@ def list_all_jobs(request):
 
 
 def get_cts_vts_version_from(cts_vts_url, default_cts_vts_version=""):
-    if cts_vts_url is None or len(cts_vts_url) ==0:
+    if cts_vts_url is None or len(cts_vts_url) == 0:
         return cts_vts_url
 
-    if cts_vts_url.find('aosp-master-throttled') >= 0:
+    if cts_vts_url.find('/aosp-master-throttled/') >= 0 or \
+            cts_vts_url.find('/aosp-master/') >= 0:
         # http://testdata.linaro.org/lkft/aosp-stable/aosp-master-throttled/7384311/test_suites_arm64/android-cts.zip
         cts_vts_url = re.sub('\/+', '/', cts_vts_url)
         return "%s#%s" % (cts_vts_url.split('/')[-4], cts_vts_url.split('/')[-3])
-    elif cts_vts_url.find('protected') >= 0:
+    elif cts_vts_url.find('/protected/') >= 0:
         # http://snapshots.linaro.org/android/lkft/protected/aosp/android-cts/84/android-cts.zip
         if len(default_cts_vts_version.split('#')) == 2 and len(default_cts_vts_version.split('/')) == 3:
             # for case like "EAP-Android12#S/SP1A.210605.001/88"


### PR DESCRIPTION
so that don't need to spend time on the test numbers check
for builds that unnecessary

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>