### PR TITLE
kernelreport.sh: always have the kernel version in the name of the re…

### DIFF
--- a/kernelreport.sh
+++ b/kernelreport.sh
@@ -33,7 +33,7 @@ done
 if [ "X${exact_ker_version}" = "XNo" ]; then
     f_report="/tmp/kernelreport-${ker_version}.txt"
 else
-    f_report="/tmp/kernelreport-${exact_ker_version}.txt"
+    f_report="/tmp/kernelreport-${ker_version}-${exact_ker_version}.txt"
 fi
 rm -f "${f_report}.scribble"
 


### PR DESCRIPTION
…port file

so that we could avoid mistakes between EAP and normal builds

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>