### PR TITLE
add support for the android-mainline gitlab projects and fix problem when squad return list for metadata

### DIFF
--- a/lkft/management/commands/kernelreport.py
+++ b/lkft/management/commands/kernelreport.py
@@ -80,6 +80,12 @@ rawkernels = {
             '4.19q-10.0-gsi-hikey-tuxsuite',
             '4.19q-10.0-gsi-hikey960-tuxsuite',
             ],
+    'android-mainline': [
+            'android-mainlin-x15-gitlab',
+            'android-mainlin-hikey-gitlab',
+            'android-mainlin-hikey960-gitlab',
+            'android-mainlin-db845c-gitlab',
+            ],
     ########## for normal jenkins ci builds ##########
     '4.4':[
             '4.4p-10.0-gsi-hikey',
@@ -332,6 +338,36 @@ projectids = {
                                 'OS' : 'Android10',
                                 'kern' : '4.19',
                                 'branch' : 'Android-4.19-q',},
+
+    ## for mainline
+    'android-mainlin-x15-gitlab': {
+                                'slug': 'mainline-aosp-master-x15',
+                                'group':'~yongqin.liu',
+                                'hardware': 'X15',
+                                'OS' : 'AOSP',
+                                'kern' : '5.X',
+                                'branch' : 'android-mainline',},
+    'android-mainlin-hikey-gitlab': {
+                                'slug': 'mainline-gki-aosp-master-hikey',
+                                'group':'~yongqin.liu',
+                                'hardware': 'HiKey',
+                                'OS' : 'AOSP',
+                                'kern' : '5.X',
+                                'branch' : 'android-mainline',},
+    'android-mainlin-hikey960-gitlab': {
+                                'slug': 'mainline-gki-aosp-master-hikey960',
+                                'group':'~yongqin.liu',
+                                'hardware': 'HiKey960',
+                                'OS' : 'AOSP',
+                                'kern' : '5.X',
+                                'branch' : 'android-mainline',},
+    'android-mainlin-db845c-gitlab': {
+                                'slug': 'mainline-gki-aosp-master-db845c',
+                                'group':'~yongqin.liu',
+                                'hardware': 'db845',
+                                'OS' : 'AOSP',
+                                'kern' : '5.X',
+                                'branch' : 'android-mainline',},
 
     ########## for jenkins ci builds ###################
     '4.4o-8.1-hikey':


### PR DESCRIPTION

As listed in the topic, including two features:
1. add support for the android-mainline gitlab projects, for experiment purpose at the moment
2. fix problem when squad return list for metadata, which would cause the kernelreport.sh crash when there are builds resubmitted for the same kernel version