### PR TITLE
kernelreport.py: adjust the order for android-mainine reports

### DIFF
--- a/lkft/management/commands/kernelreport.py
+++ b/lkft/management/commands/kernelreport.py
@@ -81,10 +81,10 @@ rawkernels = {
             '4.19q-10.0-gsi-hikey960-tuxsuite',
             ],
     'android-mainline': [
+            'android-mainlin-db845c-gitlab',
+            'android-mainlin-hikey960-gitlab',
             'android-mainlin-x15-gitlab',
             'android-mainlin-hikey-gitlab',
-            'android-mainlin-hikey960-gitlab',
-            'android-mainlin-db845c-gitlab',
             ],
     ########## for normal jenkins ci builds ##########
     '4.4':[


### PR DESCRIPTION
should the results for db845c and hikey960 first

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>