### PR TITLE
Fix the problem to fail to get report for x15 builds

### DIFF
--- a/lkft/views.py
+++ b/lkft/views.py
@@ -1205,6 +1205,34 @@ def get_build_from_database_or_qareport(build_id, force_fetch_from_qareport=Fals
     return (qareport_build, db_report_build)
 
 
+def get_job_hash_with_db_record(db_report_job):
+    job = {}
+    job['external_url'] = db_report_job.job_url
+    job['name'] = db_report_job.job_name
+    job['attachment_url'] = db_report_job.attachment_url
+    job['id'] = db_report_job.qa_job_id
+    job['parent_job'] = db_report_job.parent_job
+    job['job_status'] = db_report_job.status
+    job['environment'] = db_report_job.environment
+    job['target'] = qa_report_api.get_project_api_url_with_project_id(db_report_job.report_build.qa_project.project_id)
+    job['target_build'] = qa_report_api.get_build_api_url_with_build_id(db_report_job.report_build.qa_build_id)
+    job['submitted'] = True
+    job['submitted_at'] = db_report_job.submitted_at
+    if db_report_job.fetched_at:
+        job['fetched'] = True
+        job['fetched_at'] = db_report_job.fetched_at
+
+    job['job_id'] = qa_report_api.get_qa_job_id_with_url(db_report_job.job_url)
+    lava_config = find_lava_config(db_report_job.job_url)
+    if lava_config:
+        job['lava_config'] = lava_config
+
+    if db_report_job.failure_msg:
+        job['failure'] = {'error_msg': db_report_job.failure_msg}
+
+    return job
+
+
 def get_jobs_for_build_from_db_or_qareport(build_id=None, force_fetch_from_qareport=False):
     needs_fetch_jobs = False
 
@@ -1222,30 +1250,7 @@ def get_jobs_for_build_from_db_or_qareport(build_id=None, force_fetch_from_qarep
             needs_fetch_jobs = True
         else:
             for db_report_job in db_report_jobs:
-                job = {}
-                job['external_url'] = db_report_job.job_url
-                job['name'] = db_report_job.job_name
-                job['attachment_url'] = db_report_job.attachment_url
-                job['id'] = db_report_job.qa_job_id
-                job['parent_job'] = db_report_job.parent_job
-                job['job_status'] = db_report_job.status
-                job['environment'] = db_report_job.environment
-                job['target'] = qa_report_api.get_project_api_url_with_project_id(db_report_job.report_build.qa_project.project_id)
-                job['target_build'] = qa_report_api.get_build_api_url_with_build_id(db_report_job.report_build.qa_build_id)
-                job['submitted'] = True
-                job['submitted_at'] = db_report_job.submitted_at
-                if db_report_job.fetched_at:
-                    job['fetched'] = True
-                    job['fetched_at'] = db_report_job.fetched_at
-
-                job['job_id'] = qa_report_api.get_qa_job_id_with_url(db_report_job.job_url)
-                lava_config = find_lava_config(db_report_job.job_url)
-                if lava_config:
-                    job['lava_config'] = lava_config
-
-                if db_report_job.failure_msg:
-                    job['failure'] = {'error_msg': db_report_job.failure_msg}
-                jobs.append(job)
+                jobs.append(get_job_hash_with_db_record(db_report_job))
 
     if force_fetch_from_qareport or needs_fetch_jobs:
         jobs = qa_report_api.get_jobs_for_build(build_id)


### PR DESCRIPTION
change to use the number of finished successfully job help to check,
if the number of the finished successfully jobs is the same as the number of all jobs,
then that means  the all the jobs are finished successfully, and should be able to be used for comparison