### PR TITLE
kernelreport.py: rename the kerne version key with branch names

### DIFF
--- a/lkft/management/commands/kernelreport.py
+++ b/lkft/management/commands/kernelreport.py
@@ -120,46 +120,46 @@ rawkernels = {
             '4.19q-10.0-gsi-hikey',
             '4.19-stable-aosp-x15',
             ],
-    '5.4-android12':[
+    'android12-5.4':[
             '5.4-gki-aosp-master-db845c',  # android12-5.4
             '5.4-gki-aosp-master-hikey960', # android12-5.4
             '5.4-aosp-master-x15', # android12-5.4
             ],
-    '5.4-android11-lts':[
+    'android11-5.4-lts':[
             '5.4-lts-gki-android11-android11-hikey960', # android11-5.4-lts
             '5.4-lts-gki-android11-android11-db845c', # android11-5.4-lts
             ],
-    '5.4-android11':[
+    'android11-5.4':[
             '5.4-gki-android11-android11-hikey960', # android11-5.4
             '5.4-gki-android11-android11-db845c', # android11-5.4
             '5.4-gki-android11-aosp-master-db845c', # android11-5.4
             '5.4-gki-android11-aosp-master-hikey960', # android11-5.4
             ],
-    '5.10-android13':[
+    'android13-5.10':[
             '5.10-gki-android13-aosp-master-db845c',
             '5.10-gki-android13-aosp-master-hikey960',
             ],
-    '5.10-android12':[
+    'android12-5.10':[
             '5.10-gki-aosp-master-db845c',
             '5.10-gki-aosp-master-hikey960',
             ],
-    'EAP510-lts':[
+    'EAP-android12-5.10-lts':[
             '5.10-lts-gki-android12-private-android12-hikey960',
             '5.10-lts-gki-android12-private-android12-db845c',
             ],
-    'EAP510':[
+    'EAP-android12-5.10':[
             '5.10-gki-private-android12-db845c',
             '5.10-gki-private-android12-hikey960',
             ],
-    'EAP54-android12':[
+    'EAP-android12-5.4':[
             '5.4-gki-private-android12-db845c', # android12-5.4
             '5.4-gki-private-android12-hikey960', # android12-5.4
             ],
-     'EAP54-android12-lts':[
+    'EAP-android12-5.4-lts':[
             '5.4-lts-gki-android12-private-android12-db845c', # android12-5.4-lts
             '5.4-lts-gki-android12-private-android12-hikey960', # android12-5.4-lts
             ],
-     'EAP54-android11':[
+    'EAP-android11-5.4':[
             '5.4-gki-android11-private-android12-db845c', # android11-5.4
             '5.4-gki-android11-private-android12-hikey960', # android11-5.4
             ],


### PR DESCRIPTION
which would be used by the gitlab setup by default too

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>