### PR TITLE
kernelreport.py: show summary number at the top

### DIFF
--- a/lcr/qa_report.py
+++ b/lcr/qa_report.py
@@ -587,6 +587,8 @@ class TestNumbers():
     number_assumption_failure = 0
     number_ignored = 0
     number_total = 0
+    number_regressions = 0
+    number_antiregressions = 0
     modules_done = 0
     modules_total = 0
     jobs_finished = 0
@@ -599,6 +601,8 @@ class TestNumbers():
         self.number_assumption_failure = self.number_assumption_failure + numbers_of_result.get('number_assumption_failure', 0)
         self.number_ignored = self.number_ignored + numbers_of_result.get('number_ignored', 0)
         self.number_total = self.number_total + numbers_of_result.get('number_total')
+        self.number_regressions = self.number_regressions + numbers_of_result.get('number_regressions', 0)
+        self.number_antiregressions = self.number_antiregressions + numbers_of_result.get('number_antiregressions', 0)
         self.modules_done = self.modules_done + numbers_of_result.get('modules_done')
         self.modules_total = self.modules_total + numbers_of_result.get('modules_total')
         self.jobs_finished = self.jobs_finished + numbers_of_result.get('jobs_finished', 0)
@@ -614,6 +618,8 @@ class TestNumbers():
             'number_assumption_failure': self.number_assumption_failure,
             'number_ignored': self.number_ignored,
             'number_total': self.number_total,
+            'number_regressions': self.number_regressions,
+            'number_antiregressions': self.number_antiregressions,
             'modules_done': self.modules_done,
             'modules_total': self.modules_total,
             'jobs_finished': self.jobs_finished,
@@ -627,6 +633,8 @@ class TestNumbers():
         self.number_assumption_failure = self.number_assumption_failure + testNumbers.number_assumption_failure
         self.number_ignored = self.number_ignored + testNumbers.number_ignored
         self.number_total = self.number_total + testNumbers.number_total
+        self.number_regressions = self.number_regressions + testNumbers.number_regressions
+        self.number_antiregressions = self.number_antiregressions + testNumbers.number_antiregressions
         self.modules_done = self.modules_done + testNumbers.modules_done
         self.modules_total = self.modules_total + testNumbers.modules_total
         self.jobs_finished = self.jobs_finished + testNumbers.jobs_finished
@@ -648,6 +656,11 @@ class TestNumbers():
         if hasattr(db_record, 'jobs_total'):
             self.jobs_total = self.jobs_total + testNumbers.jobs_total
 
+        if hasattr(db_record, 'number_regressions'):
+            self.number_regressions = self.number_regressions + db_record.number_regressions
+        if hasattr(db_record, 'number_antiregressions'):
+            self.number_antiregressions = self.number_antiregressions + testNumbers.number_antiregressions
+
         return self
 
 
@@ -665,6 +678,10 @@ class TestNumbers():
         if hasattr(db_record, 'jobs_total'):
             db_record.jobs_total = self.jobs_total
 
+        if hasattr(db_record, 'number_regressions'):
+            db_record.number_regressions = self.number_regressions
+        if hasattr(db_record, 'number_antiregressions'):
+            db_record.number_antiregressions = self.number_antiregressions
         return db_record
 
 
@@ -681,5 +698,10 @@ class TestNumbers():
             db_record.jobs_finished = numbers_of_result.get('jobs_finished', 0)
         if hasattr(db_record, 'jobs_total'):
             db_record.jobs_total = numbers_of_result.get('jobs_total', 0)
+
+        if hasattr(db_record, 'number_regressions'):
+            db_record.number_regressions = numbers_of_result.get('number_regressions', 0)
+        if hasattr(db_record, 'number_antiregressions'):
+            db_record.number_antiregressions = numbers_of_result.get('number_antiregressions', 0)
 
         return db_record

--- a/lkft/management/commands/kernelreport.py
+++ b/lkft/management/commands/kernelreport.py
@@ -1147,7 +1147,7 @@ def report_results(output, run, regressions, combo, priorrun, flakes, antiregres
     output.write("\n")
 
 
-def report_kernels_in_report(path_outputfile, unique_kernels, unique_kernel_info):
+def report_kernels_in_report(path_outputfile, unique_kernels, unique_kernel_info, work_total_numbers):
     with open(path_outputfile, "w") as f_outputfile:
         f_outputfile.write("\n")
         f_outputfile.write("\n")
@@ -1162,6 +1162,16 @@ def report_kernels_in_report(path_outputfile, unique_kernels, unique_kernel_info
             for combo in intercombo:
                 f_outputfile.write(", "+ combo)
             f_outputfile.write("\n")
+
+        f_outputfile.write("\n")
+        f_outputfile.write("    %d Prior Failures now pass\n" % work_total_numbers.number_antiregressions)
+        f_outputfile.write("    %d Regressions of %d Failures, %d Passed, %d Ignored, %d Assumption Failures, %d Total\n" % (
+                                work_total_numbers.number_regressions,
+                                work_total_numbers.number_failed,
+                                work_total_numbers.number_passed,
+                                work_total_numbers.number_ignored,
+                                work_total_numbers.number_assumption_failure,
+                                work_total_numbers.number_total))
 
 
 class Command(BaseCommand):
@@ -1226,6 +1236,8 @@ class Command(BaseCommand):
         output_errorprojects = open(f_errorprojects, "w")
         do_boilerplate(output)
 
+
+        work_total_numbers = qa_report.TestNumbers()
         for combo in work:
             project_info = projectids[combo]
             project_id = project_info.get('project_id', None)
@@ -1285,9 +1297,12 @@ class Command(BaseCommand):
                 add_unique_kernel(unique_kernels, goodruns[1]['version'], combo, unique_kernel_info)
                 regressions = find_regressions(goodruns)
                 antiregressions = find_antiregressions(goodruns)
+                goodruns[1].get('numbers').number_regressions = len(regressions)
+                goodruns[1].get('numbers').number_antiregressions = len(antiregressions)
+                work_total_numbers.addWithTestNumbers(goodruns[1].get('numbers'))
                 report_results(output, goodruns[1], regressions, combo, goodruns[0], flakes, antiregressions)
 
-        report_kernels_in_report(path_outputfile, unique_kernels, unique_kernel_info)
+        report_kernels_in_report(path_outputfile, unique_kernels, unique_kernel_info, work_total_numbers)
         output.close()
         output_errorprojects.close()
         


### PR DESCRIPTION
which is the sum of all the combos,

also add the support for the regressions number and
antiregressions number

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>