### PR TITLE
remove 4.14-stable-android12-hikey960-lkft from android-hikey-linaro-…

### DIFF
--- a/lkft/reportconfig.py
+++ b/lkft/reportconfig.py
@@ -66,7 +66,6 @@ rawkernels = {
     'android-hikey-linaro-4.14-stable-lkft': [
             '4.14-stable-master-hikey960-lkft',
             '4.14-stable-master-hikey-lkft',
-            '4.14-stable-android12-hikey960-lkft',
             '4.14-stable-android11-hikey960-lkft',
             ],
     'android-beagle-x15-4.14-stable-lkft': [


### PR DESCRIPTION
…4.14-stable-lkft

as it will be reported separately by EAP-4.14-stable

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>