### PR TITLE
reportconfig.py: add support for public android12 projects

### DIFF
--- a/lkft/reportconfig.py
+++ b/lkft/reportconfig.py
@@ -8,28 +8,31 @@ rawkernels = {
     'android13-510-db845c-presubmit': [
             '5.10-gki-android13-aosp-master-db845c-presubmit',
             ],
-    'EAP-android12-54-db845c-presubmit': [
-            '5.4-gki-private-android12-db845c-presubmit',
+    'android12-54-db845c-presubmit': [
+            '5.4-gki-android12-android12-db845c-presubmit',
             ],
-    'EAP-android12-510-db845c-presubmit': [
-            '5.10-gki-private-android12-db845c-presubmit',
+    'android12-510-db845c-presubmit': [
+            '5.10-gki-android12-android12-db845c-presubmit',
             ],
 
     'android-4.9-q-hikey':[
             '4.9q-10.0-gsi-hikey960',
             '4.9q-10.0-gsi-hikey',
             '4.9q-android11-hikey960',
+            '4.9q-android12gsi-hikey960',
             ],
     'android-4.14-q-hikey': [
             '4.14q-10.0-gsi-hikey960',
             '4.14q-10.0-gsi-hikey',
             '4.14q-android11-hikey960',
+            '4.14q-android12gsi-hikey960',
             '4.14q-master-hikey960'
             ],
     'android-hikey-linaro-4.14-stable-lkft': [
             '4.14-stable-master-hikey960-lkft',
             '4.14-stable-master-hikey-lkft',
             '4.14-stable-android11-hikey960-lkft',
+            '4.14-stable-android12-hikey960-lkft-public',
             ],
     'android-beagle-x15-4.14-stable-lkft': [
             '4.14-stable-aosp-x15',
@@ -38,6 +41,7 @@ rawkernels = {
             '4.19q-10.0-gsi-hikey960',
             '4.19q-10.0-gsi-hikey',
             '4.19q-android11-hikey960',
+            '4.19q-android12gsi-hikey960',
             '4.19q-master-hikey960',
             ],
     'android-hikey-linaro-4.19-stable-lkft': [
@@ -48,23 +52,14 @@ rawkernels = {
     'android-beagle-x15-4.19-stable-lkft': [
             '4.19-stable-aosp-x15',
             ],
-    'EAP-4.9q':[
-            '4.9q-android12-hikey960',
-            ],
-    'EAP-4.14q':[
-            '4.14q-android12-hikey960',
-            ],
-    'EAP-4.14-stable':[
-            '4.14-stable-android12-hikey960-lkft',
-            ],
-    'EAP-4.19q':[
-            '4.19q-android12-hikey960',
-            ],
+
     'android12-5.4':[
             '5.4-gki-aosp-master-db845c',  # android12-5.4
             '5.4-gki-aosp-master-hikey960', # android12-5.4
             '5.4-aosp-master-x15', # android12-5.4
             '5.4-gki-android12-android11-db845c', # android12-5.4
+            '5.4-gki-android12-android12-db845c', # android12-5.4
+            '5.4-gki-android12-android12-hikey960', # android12-5.4
             ],
     'android11-5.4-lts':[
             '5.4-lts-gki-android11-android11-db845c', # android11-5.4-lts
@@ -73,6 +68,8 @@ rawkernels = {
     'android11-5.4':[
             '5.4-gki-android11-android11-db845c', # android11-5.4
             '5.4-gki-android11-android11-hikey960', # android11-5.4
+            '5.4-gki-android11-android12-db845c', # android11-5.4
+            '5.4-gki-android11-android12-hikey960', # android11-5.4
             '5.4-gki-android11-aosp-master-db845c', # android11-5.4
             '5.4-gki-android11-aosp-master-hikey960', # android11-5.4
             ],
@@ -83,30 +80,20 @@ rawkernels = {
     'android12-5.10':[
             '5.10-gki-aosp-master-db845c',
             '5.10-gki-aosp-master-hikey960',
+            '5.10-gki-android12-android12-db845c',
+            '5.10-gki-android12-android12-hikey960',
             ],
     'android13-5.15':[
             '5.15-gki-android13-aosp-master-db845c',
             ],
 
-    'EAP-android12-5.10-lts':[
-            '5.10-lts-gki-android12-private-android12-db845c',
-            '5.10-lts-gki-android12-private-android12-hikey960',
+    'android12-5.10-lts':[
+            '5.10-lts-gki-android12-android12-db845c',
+            '5.10-lts-gki-android12-android12-hikey960',
             ],
-    'EAP-android12-5.10':[
-            '5.10-gki-private-android12-db845c',
-            '5.10-gki-private-android12-hikey960',
-            ],
-    'EAP-android12-5.4':[
-            '5.4-gki-private-android12-db845c', # android12-5.4
-            '5.4-gki-private-android12-hikey960', # android12-5.4
-            ],
-    'EAP-android12-5.4-lts':[
-            '5.4-lts-gki-android12-private-android12-db845c', # android12-5.4-lts
-            '5.4-lts-gki-android12-private-android12-hikey960', # android12-5.4-lts
-            ],
-    'EAP-android11-5.4':[
-            '5.4-gki-android11-private-android12-db845c', # android11-5.4
-            '5.4-gki-android11-private-android12-hikey960', # android11-5.4
+    'android12-5.4-lts':[
+            '5.4-lts-gki-android12-android12-db845c', # android12-5.4-lts
+            '5.4-lts-gki-android12-android12-hikey960', # android12-5.4-lts
             ],
     'android-mainline':[
             'mainline-gki-aosp-master-db845c',
@@ -118,8 +105,8 @@ rawkernels = {
     'android13-5.10-full-cts-vts':[
             '5.10-gki-android13-aosp-master-db845c-full-cts-vts',
             ],
-    'EAP-android12-5.10-full-cts-vts':[
-            '5.10-gki-private-android12-db845c-full-cts-vts',
+    'android12-5.10-full-cts-vts':[
+            '5.10-gki-android12-android12-db845c-full-cts-vts',
             ],
     'android11-5.4-full-cts-vts':[
             '5.4-gki-android11-android11-db845c-full-cts-vts',
@@ -146,8 +133,8 @@ projectids = {
                      'OS' : 'Android11',
                      'kern' : '4.9',
                      'branch': 'Android-4.9-q',},
-    '4.9q-android12-hikey960':
-                    {'slug': '4.9q-android12-hikey960',
+    '4.9q-android12gsi-hikey960':
+                    {'slug': '4.9q-android12gsi-hikey960',
                      'group':'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
@@ -173,8 +160,8 @@ projectids = {
                      'OS' : 'Android11',
                      'kern' : '4.14',
                      'branch': 'Android-4.14-q',},
-    '4.14q-android12-hikey960':
-                    {'slug': '4.14q-android12-hikey960',
+    '4.14q-android12gsi-hikey960':
+                    {'slug': '4.14q-android12gsi-hikey960',
                      'group':'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
@@ -213,8 +200,8 @@ projectids = {
                      'OS' : 'Android11',
                      'kern' : '4.14',
                      'branch': 'Android-4.14-stable',},
-    '4.14-stable-android12-hikey960-lkft':
-                    {'slug': '4.14-stable-android12-hikey960-lkft',
+    '4.14-stable-android12-hikey960-lkft-public':
+                    {'slug': '4.14-stable-android12-hikey960-lkft-public',
                      'group':'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
@@ -268,8 +255,8 @@ projectids = {
                      'OS' : 'Android11',
                      'kern' : '4.19',
                      'branch': 'Android-4.19-q',},
-    '4.19q-android12-hikey960':
-                    {'slug': '4.19q-android12-hikey960',
+    '4.19q-android12gsi-hikey960':
+                    {'slug': '4.19q-android12gsi-hikey960',
                      'group':'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
@@ -365,13 +352,6 @@ projectids = {
                      'OS' : 'Android11',
                      'kern' : '5.4',
                      'branch' : 'Android11-5.4',},
-    '5.4-gki-android11-android11-hikey960-full-cts-vts':
-                    {'slug': '5.4-gki-android11-android11-hikey960-full-cts-vts',
-                     'group':'android-lkft',
-                     'hardware': 'hikey960',
-                     'OS' : 'Android11',
-                     'kern' : '5.4',
-                     'branch' : 'Android11-5.4',},
 
     # projects for android12-5.10
     '5.10-gki-aosp-master-hikey960':
@@ -386,36 +366,31 @@ projectids = {
                      'OS' : 'AOSP',
                      'kern' : '5.10',
                      'branch' : 'Android12-5.10',},
-    '5.10-gki-private-android12-db845c':
-                    {'project_id': 617,
-                     'hardware': 'db845',
-                     'OS' : 'Android12',
-                     'kern' : '5.10',
-                     'branch' : 'Android12-5.10',},
-    '5.10-gki-private-android12-db845c-presubmit':
-                    {'slug': '5.10-gki-private-android12-db845c-presubmit',
+    '5.10-gki-android12-android12-db845c':
+                    {'slug': '5.10-gki-android12-android12-db845c',
                      'group':'android-lkft',
                      'hardware': 'db845',
                      'OS' : 'Android12',
                      'kern' : '5.10',
                      'branch' : 'Android12-5.10',},
-    '5.10-gki-private-android12-hikey960':
-                    {'project_id': 616,
+    '5.10-gki-android12-android12-db845c-presubmit':
+                    {'slug': '5.10-gki-android12-android12-db845c-presubmit',
+                     'group':'android-lkft',
+                     'hardware': 'db845',
+                     'OS' : 'Android12',
+                     'kern' : '5.10',
+                     'branch' : 'Android12-5.10',},
+    '5.10-gki-android12-android12-hikey960':
+                    {'slug': '5.10-gki-android12-android12-hikey960',
+                     'group':'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
                      'kern' : '5.10',
                      'branch' : 'Android12-5.10',},
-    '5.10-gki-private-android12-db845c-full-cts-vts':
-                    {'slug': '5.10-gki-private-android12-db845c-full-cts-vts',
+    '5.10-gki-android12-android12-db845c-full-cts-vts':
+                    {'slug': '5.10-gki-android12-android12-db845c-full-cts-vts',
                      'group':'android-lkft',
                      'hardware': 'db845c',
-                     'OS' : 'Android12',
-                     'kern' : '5.10',
-                     'branch' : 'Android12-5.10',},
-    '5.10-gki-private-android12-hikey960-full-cts-vts':
-                    {'slug': '5.10-gki-private-android12-hikey960-full-cts-vts',
-                     'group':'android-lkft',
-                     'hardware': 'hikey960',
                      'OS' : 'Android12',
                      'kern' : '5.10',
                      'branch' : 'Android12-5.10',},
@@ -447,24 +422,17 @@ projectids = {
                      'OS' : 'Android13',
                      'kern' : '5.10',
                      'branch' : 'Android13-5.10',},
-    '5.10-gki-android13-aosp-master-hikey960-full-cts-vts':
-                    {'slug': '5.10-gki-android13-aosp-master-hikey960-full-cts-vts',
-                     'group':'android-lkft',
-                     'hardware': 'hikey960',
-                     'OS' : 'Android13',
-                     'kern' : '5.10',
-                     'branch' : 'Android13-5.10',},
 
     # projects for android12-5.10-lts
-    '5.10-lts-gki-android12-private-android12-hikey960':
-                    {'slug': '5.10-lts-gki-android12-private-android12-hikey960',
+    '5.10-lts-gki-android12-android12-hikey960':
+                    {'slug': '5.10-lts-gki-android12-android12-hikey960',
                      'group': 'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
                      'kern' : '5.10',
                      'branch' : 'Android12-5.10-lts',},
-    '5.10-lts-gki-android12-private-android12-db845c':
-                    {'slug': '5.10-lts-gki-android12-private-android12-db845c',
+    '5.10-lts-gki-android12-android12-db845c':
+                    {'slug': '5.10-lts-gki-android12-android12-db845c',
                      'group': 'android-lkft',
                      'hardware': 'db845',
                      'OS' : 'Android12',
@@ -472,36 +440,38 @@ projectids = {
                      'branch' : 'Android12-5.10-lts',},
 
     # projects for android12-5.4
-    '5.4-gki-private-android12-db845c':
-                    {'project_id': 620,
+    '5.4-gki-android12-android12-db845c':
+                    {'slug': '5.4-gki-android12-android12-db845c',
+                     'group': 'android-lkft',
                      'hardware': 'db845',
                      'OS' : 'Android12',
                      'kern' : '5.4',
                      'branch' : 'Android12-5.4',},
-    '5.4-gki-private-android12-db845c-presubmit':
-                    {'slug': '5.4-gki-private-android12-db845c-presubmit',
+    '5.4-gki-android12-android12-db845c-presubmit':
+                    {'slug': '5.4-gki-android12-android12-db845c-presubmit',
                      'group':'android-lkft',
                      'hardware': 'db845',
                      'OS' : 'Android12',
                      'kern' : '5.4',
                      'branch' : 'Android12-5.4',},
-    '5.4-gki-private-android12-hikey960':
-                    {'project_id': 621,
+    '5.4-gki-android12-android12-hikey960':
+                    {'slug': '5.4-gki-android12-android12-hikey960',
+                     'group':'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
                      'kern' : '5.4',
                      'branch' : 'Android12-5.4',},
 
     # projects for android12-5.4-lts
-    '5.4-lts-gki-android12-private-android12-hikey960':
-                    {'slug': '5.4-lts-gki-android12-private-android12-hikey960',
+    '5.4-lts-gki-android12-android12-hikey960':
+                    {'slug': '5.4-lts-gki-android12-android12-hikey960',
                      'group': 'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
                      'kern' : '5.4',
                      'branch' : 'Android12-5.4-lts',},
-    '5.4-lts-gki-android12-private-android12-db845c':
-                    {'slug': '5.4-lts-gki-android12-private-android12-db845c',
+    '5.4-lts-gki-android12-android12-db845c':
+                    {'slug': '5.4-lts-gki-android12-android12-db845c',
                      'group': 'android-lkft',
                      'hardware': 'db845',
                      'OS' : 'Android12',
@@ -509,15 +479,15 @@ projectids = {
                      'branch' : 'Android12-5.4-lts',},
 
     # projects for android11-5.4
-    '5.4-gki-android11-private-android12-hikey960':
-                    {'slug': '5.4-gki-android11-private-android12-hikey960',
+    '5.4-gki-android11-android12-hikey960':
+                    {'slug': '5.4-gki-android11-android12-hikey960',
                      'group': 'android-lkft',
                      'hardware': 'HiKey960',
                      'OS' : 'Android12',
                      'kern' : '5.4',
                      'branch' : 'Android11-5.4',},
-    '5.4-gki-android11-private-android12-db845c':
-                    {'slug': '5.4-gki-android11-private-android12-db845c',
+    '5.4-gki-android11-android12-db845c':
+                    {'slug': '5.4-gki-android11-android12-db845c',
                      'group': 'android-lkft',
                      'hardware': 'db845',
                      'OS' : 'Android12',


### PR DESCRIPTION
including:
    4.9q-android12gsi-hikey960
    4.14q-android12gsi-hikey960
    4.14-stable-android12-hikey960-lkft-public
    4.19q-android12gsi-hikey960

    5.4-gki-android11-android12-hikey960
    5.4-gki-android12-android12-hikey960
    5.4-lts-gki-android12-android12-hikey960
    5.10-gki-android12-android12-hikey960
    5.10-lts-gki-android12-android12-hikey960

    5.4-gki-android11-android12-db845c
    5.4-gki-android12-android12-db845c
    5.4-lts-gki-android12-android12-db845c
    5.10-gki-android12-android12-db845c
    5.10-lts-gki-android12-android12-db845c

    5.4-gki-android12-android12-db845c-presubmit
    5.10-gki-android12-android12-db845c-presubmit
    5.10-gki-android12-android12-db845c-full-cts-vts

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>