### PR TITLE
lkft: move installation for ruamel.yaml to requirements.txt

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -64,7 +64,6 @@ pip install -r ${instance_dir}/requirements.txt
 #pip install bugzilla
 ## pip install Pillow
 ## pip install rst2pdf
-python3 -m pip install ruamel.yaml
 
 # https://docs.djangoproject.com/en/1.11/intro/tutorial01/
 python3 -m django --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ reportlab
 psycopg2
 python-dateutil
 matplotlib
+ruamel.yaml


### PR DESCRIPTION
instead of running the pip install command separately