### PR TITLE
lkft_config.py: set hardware name for RB5

### DIFF
--- a/lkft/lkft_config.py
+++ b/lkft/lkft_config.py
@@ -360,6 +360,8 @@ def get_hardware_from_pname(pname=None, env=''):
         return 'AM65X'
     elif pname.find('db845c') >= 0:
         return 'Dragonboard 845c'
+    elif pname.find('rb5') >= 0:
+        return 'RB5'
     else:
         return 'Other'
 


### PR DESCRIPTION
so that bugs could be created successfully

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>