### PR TITLE
Some improvements for triage work

### DIFF
--- a/lcr/qa_report.py
+++ b/lcr/qa_report.py
@@ -599,11 +599,30 @@ class QAReportApi(RESTFullApi):
         return self.call_with_api_url(api_url=api_url, method='POST', returnResponse=True, post_data=post_data)
 
 
-    '''
-        not work yet, not exported by the qa-report api yet
-    '''
     def canceljob(self, qa_job_id):
-        api_url = 'api/cancel/%s' % qa_job_id
+        api_url = 'api/testjobs/%s/cancel' % qa_job_id
+        return self.call_with_api_url(api_url=api_url, method='POST', returnResponse=True)
+
+
+    def get_environment_with_url(self, environment_url):
+        return self.call_with_full_url(request_url=environment_url)
+
+    def get_backend_with_url(self, backend_url):
+        return self.call_with_full_url(request_url=backend_url)
+
+    def get_group_with_url(self, group_url):
+        return self.call_with_full_url(request_url=group_url)
+
+    def fetchjob(self, qa_job_id):
+        qa_job = self.get_job_with_id(qa_job_id)
+        qa_build = self.get_build_with_url(qa_job.get("target_build"))
+        qa_project = self.get_project_with_url(qa_job.get("target"))
+        qa_group = self.get_group_with_url(qa_project.get("group"))
+        qa_backend = self.get_backend_with_url(qa_job.get("backend"))
+
+        # group_slug, project_slug, version, environment_slug, backend_name
+        api_url = 'api/fetchjob/%s/%s/%s/%s/%s' % (qa_group.get('slug'), qa_project.get("slug"), qa_build.get("version"), qa_job.get("environment"), qa_backend.get("name"))
+        logger.info(f"fetchjob api url={api_url}")
         return self.call_with_api_url(api_url=api_url, method='POST', returnResponse=True)
 
     '''
@@ -768,12 +787,12 @@ class TestNumbers():
         if hasattr(db_record, 'jobs_finished'):
             self.jobs_finished = self.jobs_finished + db_record.jobs_finished
         if hasattr(db_record, 'jobs_total'):
-            self.jobs_total = self.jobs_total + testNumbers.jobs_total
+            self.jobs_total = self.jobs_total + db_record.jobs_total
 
         if hasattr(db_record, 'number_regressions'):
             self.number_regressions = self.number_regressions + db_record.number_regressions
         if hasattr(db_record, 'number_antiregressions'):
-            self.number_antiregressions = self.number_antiregressions + testNumbers.number_antiregressions
+            self.number_antiregressions = self.number_antiregressions + db_record.number_antiregressions
 
         return self
 

--- a/lkft/templates/lkft-describe.html
+++ b/lkft/templates/lkft-describe.html
@@ -1,10 +1,29 @@
 {% extends '_layouts/base.html' %}
 
-{% block title %} {{kernel_change.describe}} {% endblock %}
+{% load static %}
+{% load escapesharp %}
+{% load startswith %}
 
-{% block headline %}<h1>{{kernel_change.describe}}</h1>{% endblock %}
+{% block title %} {{kernel_change.branch}} {{kernel_change.describe}} {% endblock %}
+
+{% block headline %}<h1>{{kernel_change.branch}} > {{kernel_change.describe}}</h1>{% endblock %}
+
+{% block css %}
+<link rel="stylesheet" href="{% static "report/css/compatibility_result.css" %}">
+{% endblock %}
 
 {% block content %}
+<div class="row">
+<table class="table"><tbody><tr>
+        <td style="text-align: right;">
+            {% if fetch_latest %}
+                <a href="/lkft/kernel-changes/{{kernel_change.branch}}/{{kernel_change.describe}}">Only show data cached</a>
+            {% else %}
+                <a href="/lkft/kernel-changes/{{kernel_change.branch}}/{{kernel_change.describe}}?fetch_latest=true">Refresh with the latest data</a>
+            {% endif %}
+        </td>
+    </tr></tbody></table>
+</div>
 
 <div>
 <h1>Summary</h1>
@@ -31,7 +50,7 @@
     </tr>
     <tr>
         <th>Trigger</th>
-        <td><a href="https://ci.linaro.org/job/{{kernel_change.trigger_name}}/{{kernel_change.trigger_number}}">{{kernel_change.trigger_name}}#{{kernel_change.trigger_number}}</a></td>
+        <td><a href="https://gitlab.com/Linaro/lkft/users/yongqin.liu/{{kernel_change.trigger_name}}/-/pipelines/{{kernel_change.trigger_number}}">{{kernel_change.trigger_name}}#{{kernel_change.trigger_number}}</a></td>
     </tr>
     <tr>
         <th>Started At</th>
@@ -96,8 +115,8 @@
         <th>Duration</th>
 </tr>
 <tr>
-    <td><a href="https://ci.linaro.org/job/{{trigger_build.name}}/">{{trigger_build.name}}</a></td>
-    <td align='right'><a href="https://ci.linaro.org/job/{{trigger_build.name}}/{{trigger_build.number}}/">{{trigger_build.number}}</a></td>
+    <td><a href="https://gitlab.com/Linaro/lkft/users/yongqin.liu/{{trigger_build.name}}/~/pipelines">{{trigger_build.name}}</a></td>
+    <td align='right'><a href="https://gitlab.com/Linaro/lkft/users/yongqin.liu/{{trigger_build.name}}/~/pipelines/{{trigger_build.number}}/">{{trigger_build.number}}</a></td>
     <td>{{trigger_build.result}}</td>
     <td><p>Started at {{ trigger_build.timestamp|date:'M. d, Y, H:i'}}, <br/>{{ trigger_build.timestamp|timesince}} ago</p></td>
     <td align='right'>{{trigger_build.duration}}</td>
@@ -120,8 +139,8 @@
 {% for cibuild in ci_builds %}
 <tr>
     <td>{{ forloop.counter }}</td>
-    <td><a href="https://ci.linaro.org/job/{{cibuild.name}}/">{{cibuild.name}}</a></td>
-    <td align='right'><a href="https://ci.linaro.org/job/{{cibuild.name}}/{{cibuild.number}}/">{{cibuild.number}}</a></td>
+    <td><a href="https://gitlab.com/Linaro/lkft/users/yongqin.liu/{{cibuild.name}}/-/pipelines/">{{cibuild.name}}</a></td>
+    <td align='right'><a href="https://gitlab.com/Linaro/lkft/users/yongqin.liu/{{cibuild.name}}/-/pipelines/{{cibuild.number}}/">{{cibuild.number}}</a></td>
     <td>{{cibuild.result}}</td>
     <td align='right'>{{cibuild.queued_duration}}</td>
     <td><p>Started at {{ cibuild.timestamp|date:'M. d, Y, H:i'}}, <br/>{{ cibuild.timestamp|timesince}} ago</p></td>
@@ -208,16 +227,26 @@
     <td> {{job.qaproject_group }}</td>
     <td> {{job.qaproject_name }}</td>
     <td> <a href="{{job.lavajob_url}}">{{job.lavajob_id}}</a> </td>
-    {% if job.lavajob_url %}
-    <td nowrap> <a target='_blank' href="{{job.lavajob_url}}">{{job.lavajob_name}} </a></td>
+    {% if job.lavajob_attachment_url %}
+    <td nowrap> <a target='_blank' href="{{job.lavajob_attachment_url}}">{{job.lavajob_name}} </a></td>
     {% else %}
     <td nowrap> {{job.lavajob_name}}</td>
     {% endif %}
-    <td>{{job.lavajob_status}} </td>
+    {% if job.lavajob_status == 'NotSubmitted' %}
+    <td>{{job.lavajob_status}}</td>
+    {% else %}
+    <td><a target='_blank' href="/lkft/lavalog/{{job.qajob_id}}/">{{job.lavajob_status}}</a></td>
+    {% endif %}
     {% if job.lavajob_status == 'Running' or job.lavajob_status == 'Submitted'%}
     <td>&nbsp;</td>
     {% else %}
-    <td><a target='_blank' href="/lkft/resubmit-job/?qa_job_id={{job.qajob_id}}">Resubmit</a> </td>
+    <td>
+        <a target='_blank' href="/lkft/resubmit-job-manual/{{job.qajob_id}}?&no_update=true">Resubmit</a>
+        &nbsp;/&nbsp;
+        <a target='_blank' href="/lkft/resubmit-job-manual/{{job.qajob_id}}?no_update=false">Manual</a>
+        &nbsp;/&nbsp;
+        <a target='_blank' href="/lkft/fetch-job/{{job.qajob_id}}">Fetch</a>
+    </td>
     {% endif %}
     {% if job.failure_msg %}
     <td>{{job.failure_msg}} </td>
@@ -229,7 +258,13 @@
     <td align="right">{{job.number_assumption_failure}}</td>
     <td align="right">{{job.number_ignored}}</td>
     <td align="right">{{job.number_total}}</td>
-    <td align="right">{{job.modules_done}}/{{job.modules_total}}</td>
+    <td align="right">
+    {% if job.modules_done != job.modules_total or job.is_cts_vts_job and job.modules_total == 0 %}
+    <p style="background-color: red">{{job.modules_done}}/{{job.modules_total}}</p>
+    {% else %}
+    {{job.modules_done}}/{{job.modules_total}}
+    {% endif %}
+    </td>
 </tr>
 {% endfor %}
 </table>
@@ -272,5 +307,71 @@
 </table>
 </div>
 {% endif %}
+{% endif %}
+
+{% if failures %}
+<script type="text/javascript">
+    function toggle() {
+      for (var i = 0; i < arguments.length; i++) {
+        var e = document.getElementById(arguments[i]);
+        if (e) {
+          e.style.display = e.style.display == 'none' ? 'block': 'none';
+        }
+      }
+      return false;
+    }
+    function moduleToggle(link, id) {
+      toggle('module-details-' + id);
+      var s = link.getElementsByTagName('span')[0];
+      var uarr = String.fromCharCode(0x25b6);
+      var darr = String.fromCharCode(0x25bc);
+      s.textContent = s.textContent == uarr ? darr : uarr;
+      return false;
+    }
+</script>
+<div align="left">
+<h2>Details of Failures</h2>
+{% for module_name, module_failures in failures.items %}
+{% if module_failures|length > 0 %}
+<div>
+    <a href="#" onclick="return moduleToggle(this, '{{module_name}}')" name="{{module_name}}"><span>▶</span> {{module_name}} has {{ module_failures|length }} failures</a>
+</div>
+<table id="module-details-{{module_name}}" class="testdetails" style="display: none;">
+<tbody>
+<tr>
+    <th>Index</th>
+    <th>Test</th>
+    <th>Result</th>
+    <th>Kernels</th>
+    <th>Projects</th>
+</tr>
+{% for testcase_name, failure in module_failures.items %}
+<tr>
+    <td> {{ forloop.counter }}</td>
+    <td class="testname">{{failure.test_name}}</td>
+    <td class="testname">{{failure.result}}</td>
+    <td class="testname" nowrap>
+        {% with failure.kernel_versions as kernel_versions %}
+        {% for kernel_version in kernel_versions %}
+        {% if not forloop.first %}<br/>{% endif %}
+        {{ kernel_version }}
+        {% endfor %}
+        {% endwith %}
+    </td>
+    <td class="testname" nowrap>
+        {% with failure.project_names as project_names %}
+        {% for project_name in project_names %}
+        {% if not forloop.first %}<br/>{% endif %}
+        {{ project_name }}
+        {% endfor %}
+        {% endwith %}
+    </td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endif %}
+{% endfor %}
+</div>
 {% endif %}
 {% endblock %}

--- a/lkft/templates/lkft-gitlab-project-pipelines.html
+++ b/lkft/templates/lkft-gitlab-project-pipelines.html
@@ -30,6 +30,13 @@
 			<th>Updated At</th>
 			<th>Kernel Branch</th>
 			<th>Kernel Describe<br/>(Need login gitlab to download artifacts)</th>
+			<th>Passed</th>
+			<th>Failed</th>
+			<th>AssumptionF</th>
+			<th>Ignored</th>
+			<th>Total</th>
+			<th>Modules Done/Total</th>
+			<th>Jobs Completed/Total</th>
 	</tr>
 	{% for pipeline in pipelines %}
 	<tr>
@@ -46,12 +53,49 @@
 
 	    <td>{{ pipeline.created_at_datetime|date:'M. d, Y, H:i'}}, <br/>{{ pipeline.created_at_datetime|timesince}} ago</td>
 	    <td>{{ pipeline.updated_at_datetime|date:'M. d, Y, H:i'}}, <br/>{{ pipeline.updated_at_datetime|timesince}} ago</td>
-	    <td>{{pipeline.branch}}</td>
+	    <td><a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/">{{pipeline.branch}}</a></td>
+        <td>
 	    {% if pipeline.artifacts_url %}
-	    <td><a target='_blank' href="{{pipeline.artifacts_url}}">{{pipeline.kernel_describe}}</a></td>
+	    <a target='_blank' href="{{pipeline.artifacts_url}}">{{pipeline.kernel_describe}}</a>
 	    {% else %}
-	    <td>{{pipeline.kernel_describe}}</td>
+	    {{pipeline.kernel_describe}}
 	    {% endif %}
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.number_passed}}
+            </a>
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.number_failed}}
+            </a>
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.number_assumption_failure}}
+            </a>
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.number_ignored}}
+            </a>
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.number_total}}
+            </a>
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.modules_done}}/{{pipeline.numbers.modules_total}}
+            </a>
+        </td>
+        <td align="right">
+            <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">
+                {{pipeline.numbers.jobs_finished}}/{{pipeline.numbers.jobs_total}}
+            </a>
+        </td>
 	</tr>
 	{% endfor %}
 	</table>

--- a/lkft/templates/lkft-kernelchanges.html
+++ b/lkft/templates/lkft-kernelchanges.html
@@ -45,7 +45,7 @@
     {% else %}
         <td align='right'>--</td>
     {% endif %}
-    <td><a href="https://ci.linaro.org/job/{{kernelchange.trigger_name}}/{{kernelchange.trigger_number}}">{{kernelchange.trigger_name}}#{{kernelchange.trigger_number}}</a></td>
+    <td><a href="https://gitlab.com/Linaro/lkft/users/yongqin.liu/{{kernelchange.trigger_name}}/-/pipelines/{{kernelchange.trigger_number}}">{{kernelchange.trigger_name}}#{{kernelchange.trigger_number}}</a></td>
     <td align='right'>{{kernelchange.number_passed}}</td>
     <td align='right'>{{kernelchange.number_failed}}</td>
     <td align='right'>{{kernelchange.number_assumption_failure}}</td>

--- a/lkft/templates/lkft-projects-matrix.html
+++ b/lkft/templates/lkft-projects-matrix.html
@@ -1,0 +1,45 @@
+{% extends '_layouts/base.html' %}
+
+{% load static%}
+
+{% block title %}LKFT Android Projects{% endblock %}
+
+{% block headline %}<h1><a href="https://qa-reports.linaro.org/">LKFT Android Projects</a></h1>{% endblock %}
+
+{% block css %}
+<script src="{% static "report/jquery.min.js" %}"></script>
+<script src="{% static "report/bootstrap.min.js" %}"></script>
+{% endblock %}
+{% block content %}
+<div class="row">
+{% if matrix_data %}
+<table class="table">
+<tbody>
+
+<tr>
+    <th>Kernel</td>
+    {% for android_version in android_versions %}
+    <th> {{android_version}} </th>
+    {% endfor %}
+</tr>
+
+{% for branch, os_projects in matrix_data.items %}
+<tr>
+    <td nowrap>
+    <a target='_blank' href="/lkft/kernel-changes/{{branch}}">{{branch}}</a>
+    </td>
+    {% for os, projects in os_projects.items %}
+    <td nowrap>
+    {% for project in projects %}
+    {% if not forloop.first %}<br/>{% endif %}
+    <a target='_blank' href="/lkft/builds?project_slug={{project.slug}}&&project_group={{project.group}}">{{project.slug}}{% if project.environment %}({{project.environment}}){% endif %}</a>
+    {% endfor %}
+    </td>
+    {% endfor %}
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endif %}
+</div>
+{% endblock %}

--- a/lkft/urls.py
+++ b/lkft/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     url(r'^resubmit-job/.*$', views.resubmit_job, name='resubmit_job'),
     url(r'^resubmit-job-manual/(%s)' % (numerical_pat), views.resubmit_job_manual, name='resubmit_job_manual'),
     url(r'^cancel-job/(%s)/$' % (numerical_pat), views.cancel_job, name='cancel_job'),
+    url(r'^fetch-job/(%s)/$' % (numerical_pat), views.fetch_job, name='fetch_job'),
     url(r'^cancel-build/(%s)/$' % (numerical_pat), views.cancel_build, name='cancel_build'),
     url(r'^cancel-kernelchange/(%s)/(%s)$' % (basic_pat, basic_pat), views.cancel_kernelchange, name='cancel_kernelchange'),
     # newchanges/$branch/$describe/$build_name/$build_number
@@ -36,4 +37,5 @@ urlpatterns = [
 
     url(r'^gitlab/$', views.gitlab_projects, name='gitlab_projects'),
     url(r'^gitlab/(%s)/$' % gitlab_project_id_pat, views.gitlab_project_pipelines, name='gitlab_progect_pipelines'),
+    url(r'^matrix/$', views.matrix, name='matrix'),
 ]

--- a/static/report/css/compatibility_result.css
+++ b/static/report/css/compatibility_result.css
@@ -23,6 +23,7 @@ table.testdetails {
   margin-right: auto;
   vertical-align: top;
   /* width: 95%; */
+  width: fit-content;
   font-family: arial,sans-serif;
   font-size: 13px;
 }


### PR DESCRIPTION
Still in progress, the changes here are the initial part part to improve the triage work.
Future improvements will be done after being used for a while. The features enabled here including:
1. matrix page: help to see what projects are setup now
2. describe pages linked to the pipeline pages to avoid finding projects one by one from various places and enabled fetch latest future as well, which could be called from the gitlab side, to improve the slowness problem