### PR TITLE
lkft: point to the googlesource log link on the pipeline page

### DIFF
--- a/lkft/templates/lkft-gitlab-project-pipelines.html
+++ b/lkft/templates/lkft-gitlab-project-pipelines.html
@@ -55,11 +55,7 @@
         <td>{{ pipeline.updated_at_datetime|date:'M. d, Y, H:i'}}, <br/>{{ pipeline.updated_at_datetime|timesince}} ago</td>
         <td nowrap><a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/">{{pipeline.branch}}</a></td>
         <td>
-        {% if pipeline.artifacts_url %}
-        <a target='_blank' href="{{pipeline.artifacts_url}}">{{pipeline.kernel_describe}}</a>
-        {% else %}
-        {{pipeline.kernel_describe}}
-        {% endif %}
+        <a target='_blank' href="https://android.googlesource.com/kernel/common/+log/{{pipeline.kernel_commit}}">{{pipeline.kernel_describe}}</a>
         </td>
         <td align="right">
             <a target='_blank' href="/lkft/kernel-changes/{{pipeline.branch}}/{{pipeline.kernel_describe}}">

--- a/lkft/views.py
+++ b/lkft/views.py
@@ -4121,6 +4121,14 @@ def gitlab_project_pipelines(request, project_id):
 
             pipeline['kernel_describe'] = kernel_describe
 
+            if variables_dict.get('KERNEL_COMMIT') is not None:
+                kernel_commit = variables_dict.get('KERNEL_COMMIT')
+            elif variables_dict.get('SRCREV_kernel') is not None:
+                kernel_commit = variables_dict.get('SRCREV_kernel')
+            else:
+                kernel_commit = "Unknown"
+            pipeline['kernel_commit'] = kernel_commit
+
             fetch_data_for_describe_kernelchange(branch=pipeline['branch'], describe=kernel_describe, fetch_latest_from_qa_report=fetch_latest)
             try:
                 db_kernel_change = KernelChange.objects.get(branch=pipeline['branch'], describe=kernel_describe)


### PR DESCRIPTION
The report file is not necessary, and this googlesource link will be convenient for triage