### PR TITLE
lkft/views.py: workaround for too long testcase name issue

### DIFF
--- a/lkft/views.py
+++ b/lkft/views.py
@@ -489,7 +489,9 @@ def save_tradeded_results_to_database(result_file_path, job, report_job):
                             test_name = '%s#%s' % (test_class_name, test_name)
                         else:
                             test_name = '%s#%s#%s' % (test_class_name, test_name, abi)
-
+                        # workaround for VtsHalAudioV7_0TargetTest module
+                        # which has test case names longer than 320
+                        test_name = test_name[:320]
                         test_result = test_case.get('result')
                         #result is one of: 'pass', 'fail', 'IGNORED', ASSUMPTION_FAILURE'
 


### PR DESCRIPTION
by dropping the 320+ chars of the testcase name.
The are prefix and suffix like 0_default_primary_0 could be used to identify the test cases.
The following are some of the long name test cases for reference:

    InputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/0_default_primary_0__8000_random_string_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________channelMask________tags____0______
    InputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/1_default_primary_1__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________channelMask________tags____0______
    InputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/2_default_r_submix_2__48000_random_string_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________channelMask________tags____0______
    InputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/3_default_r_submix_3__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________channelMask________tags____0______

    InputStreamInvalidAddress/StreamOpenTest#OpenInputOrOutputStreamTest/0_default_primary_0__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____random_string____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________channelMask________tags____0______
    InputStreamInvalidAddress/StreamOpenTest#OpenInputOrOutputStreamTest/1_default_r_submix_1__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____random_string____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________channelMask________tags____0______

    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/0_default_primary_0__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____random_string____gain___1_000000___destination_____unspecified_________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/1_default_primary_1__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____random_string____address_____id___________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/2_default_primary_2__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask____random_string____tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/3_default_primary_3__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____1___random_string_____
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/4_default_primary_4__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____random_string____gain___1_000000___destination_____unspecified_________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/5_default_primary_5__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____random_string____address_____id___________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/7_default_primary_7__8000_AUDIO_CHANNEL_IN_MONO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____1___random_string_____
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/8_default_r_submix_8__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____random_string____gain___1_000000___destination_____unspecified_________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/9_default_r_submix_9__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____random_string____address_____id___________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/10_default_r_submix_10__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask____random_string____tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/11_default_r_submix_11__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____1____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____1___random_string_____
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/12_default_r_submix_12__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____random_string____gain___1_000000___destination_____unspecified_________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/13_default_r_submix_13__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____device_____deviceType____random_string____address_____id___________channelMask________tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/14_default_r_submix_14__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask____random_string____tags____0______
    InputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/15_default_r_submix_15__48000_AUDIO_CHANNEL_IN_STEREO_______deviceType____AUDIO_DEVICE_IN_DEFAULT____address_____id___________tracks____2____source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____0________source____AUDIO_SOURCE_DEFAULT____gain___1_000000___destination_____unspecified_________channelMask________tags____1___random_string_____

    OutputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/0_default_primary_0__48000_random_string_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/1_default_primary_1__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/2_default_primary_2__48000_AUDIO_CHANNEL_OUT_STEREO___random_string________deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/3_default_r_submix_3__48000_random_string_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/4_default_r_submix_4__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidConfig/StreamOpenTest#OpenInputOrOutputStreamTest/5_default_r_submix_5__48000_AUDIO_CHANNEL_OUT_STEREO___random_string________deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______

    OutputStreamInvalidAddress/StreamOpenTest#OpenInputOrOutputStreamTest/0_default_primary_0__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____random_string____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______

    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/0_default_primary_0__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____random_string____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/1_default_primary_1__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____random_string____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/2_default_primary_2__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask____random_string____tags____0______
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/3_default_primary_3__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____1____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____1___random_string_____
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/4_default_primary_4__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____2____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0________usage____random_string____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/5_default_primary_5__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____2____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0________usage____AUDIO_USAGE_MEDIA____contentType____random_string____gain___1_000000___channelMask________tags____0______
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/6_default_primary_6__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____2____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0________usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask____random_string____tags____0______
    OutputStreamInvalidMetadata/StreamOpenTest#OpenInputOrOutputStreamTest/7_default_primary_7__48000_AUDIO_CHANNEL_OUT_STEREO_______deviceType____AUDIO_DEVICE_OUT_DEFAULT____address_____id___________tracks____2____usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____0________usage____AUDIO_USAGE_MEDIA____contentType____AUDIO_CONTENT_TYPE_MUSIC____gain___1_000000___channelMask________tags____1___random_string_____