### PR TITLE
lkft/views.py: use the last gitlab url

### DIFF
--- a/lkft/views.py
+++ b/lkft/views.py
@@ -3398,6 +3398,8 @@ def fetch_data_for_describe_kernelchange(branch=None, describe=None, fetch_lates
     target_build_metadata = qa_report_api.get_build_meta_with_url(first_qareport_build.get("metadata"))
     # https://gitlab.com/Linaro/lkft/users/yongqin.liu/android-common/-/pipelines/1075583866
     gitlab_url = target_build_metadata.get("pipeline.trigger.url")
+    if isinstance(gitlab_url, list):
+        gitlab_url = gitlab_url[-1]
     if gitlab_url:
         trigger_number = gitlab_url.strip('/').split('/')[-1]
         trigger_name = gitlab_url.strip('/').split('/')[-4]
@@ -3419,6 +3421,8 @@ def fetch_data_for_describe_kernelchange(branch=None, describe=None, fetch_lates
         build_metadata = qa_report_api.get_build_meta_with_url(qareport_build.get("metadata"))
         # https://gitlab.com/Linaro/lkft/users/yongqin.liu/android-common/-/pipelines/1075583866
         gitlab_url = target_build_metadata.get("build-url")
+        if isinstance(gitlab_url, list):
+            gitlab_url = gitlab_url[-1]
         if gitlab_url:
             build_number = gitlab_url.strip('/').split('/')[-1]
             build_name = gitlab_url.strip('/').split('/')[-4]


### PR DESCRIPTION
when the same commit was triggered by multiple builds