### PR TITLE
two improvements on the display of the failures and matrix

### DIFF
--- a/lkft/templates/lkft-projects-matrix.html
+++ b/lkft/templates/lkft-projects-matrix.html
@@ -43,11 +43,11 @@
         {% if project.numbers.jobs_total == 0 or project.numbers.jobs_finished != project.numbers.jobs_total  %}
             <span style="color: red">({{project.numbers.jobs_finished}}/{{project.numbers.jobs_total}})</span>
         {% elif project.numbers.number_regressions > 0 %}
-            <span style="color: red">({{project.numbers.number_regressions}}&nearr;)</span>
+            <span style="color: red">({{project.numbers.number_regressions}}&nearr;{{project.numbers.number_failed}})</span>
         {% elif project.numbers.number_regressions < 0 %}
-            <span style="color: green">({{project.numbers.number_regressions}} &searr;)</span>
+            <span style="color: green">({{project.numbers.number_regressions}}&searr;{{project.numbers.number_failed}})</span>
         {% else %}
-            <span>({{project.numbers.number_failed}} &rarr;)</span>
+            <span>(&rarr;{{project.numbers.number_failed}})</span>
         {% endif %}
     </a>
     {% endfor %}

--- a/lkft/views.py
+++ b/lkft/views.py
@@ -3944,6 +3944,11 @@ def project_history(request, group, slug):
                     module_build_failures[build_version] = build_failures
                 build_failures.append(test_dict)
 
+            # for the remain buid versions that no failures reported
+            failures_not_reported_build_versions = report_build_version_id_dict.keys() - test_dict.get('build_versions', [])
+            for build_version in failures_not_reported_build_versions:
+                module_build_failures[build_version] = []
+
         module_builds[module_name] = collections.OrderedDict(sorted(module_build_failures.items(), key=lambda item: report_build_version_id_dict.get(item[0], 0), reverse=True))
         failures[module_name] = collections.OrderedDict(sorted(failures_in_module_copy.items()))
 


### PR DESCRIPTION
410c140ca747 lkft/views.py: list all the build versions
fac1c4a37b5d lkft-projects-matrix.html: show total failed numbers always
